### PR TITLE
fix snipper scroll

### DIFF
--- a/less/site/snippet.less
+++ b/less/site/snippet.less
@@ -24,6 +24,8 @@ code {
 }
 
 .snippet {
+	display: flex;
+	overflow-x: auto;
 	font-size: 13px;
 	line-height: 20px;
 	margin: 12px 0px;


### PR DESCRIPTION
When reading docs on mobile I can't scroll snippet example

## Description

So i have found css for snippet and add ability to scroll it

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
have been tested on macos google chrome with device emulation
<!--- Include details of your testing environment, tests ran to see how -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update