### PR TITLE
Use constructor as keyword

### DIFF
--- a/content/examples/10-applications/todos/todo.imba
+++ b/content/examples/10-applications/todos/todo.imba
@@ -1,5 +1,5 @@
 export class Todo
-	def constructor title
+	constructor title
 		title = title
 		done = no
 

--- a/content/guides/10-scripting.md
+++ b/content/guides/10-scripting.md
@@ -499,7 +499,7 @@ Construtors are also known as initializer or prototype.
 ##### syntax
 ```imba
 class ClassName
-	def constructor argOne, argTwo, argThree
+	constructor argOne, argTwo, argThree
 		propOne = argOne
 		propTwo = argTwo
 		propThree = argThree
@@ -531,7 +531,7 @@ var joe = Person.new
 The above have the same three properties, but we don't want them to have the same three values. We need to pass values dynamically to each one, and that is done via arguments in the **constructor method**
 ```imba
 class Person
-	def constructor x, y, z
+	constructor x, y, z
 		name = x
 		age = y
 		job = z
@@ -554,7 +554,7 @@ console.log joe.age
 > **TIP** Imba also knows the difference between props and arguments within the cunstructor method, so you could use the same name if you wanted.
 ```imba
 class Person
-	def constructor name, age, job
+	constructor name, age, job
 		name = name
 		age = age
 		job = job
@@ -564,7 +564,7 @@ class Person
 Don't forget that Methods, are simply functions within a Class. So anything you can do in a function, you can do in a method.
 ```imba
 class Person
-	def constructor name, age, job
+	constructor name, age, job
 		name = name
 		age = age
 		job = job
@@ -583,11 +583,11 @@ For example, an Athlete is also a person, so it makes sense to inherit the prope
 
 ```imba
 class Person 
-	def constructor name, age
+	constructor name, age
 		name = name
 		age = age
 class Athlete
-	def constructor name, age, trophies
+	constructor name, age, trophies
 		name = name
 		age = age
 		trophies = trophies
@@ -601,24 +601,24 @@ class Athlete < Person
 In order to call the Parent's constructor we need to use the super() method within our Athlete's constructor.
 ```imba
 class Athlete < Person
-	def constructor
+	constructor
 		super!
 ```
 If our Person constructor did not take arguments, the above would be enough, but since we want to dynamically pass arguments from the athelete constructor to the person constructor, we need to pass them inside the `super(...)` method.
 
 ```imba
 class Athlete < Person
-	def constructor name, age
+	constructor name, age
 		super(name, age)
 ```
 We can then pass the new arguments that will be unique to the althele class.
 ```imba
 class Person
-	def constructor name, age
+	constructor name, age
 		name = name
 		age = age
 class Athlete < Person
-	def constructor name, age, trophies
+	constructor name, age, trophies
 		super(name, age) # calls the parent constructor, and passes arguments.
 		trophies = trophies
 ```
@@ -641,11 +641,11 @@ Let's grab the name prop on our greet method.
 
 ```imba
 class Person
-	def constructor name, age
+	constructor name, age
 		name = name
 		age = age
 class King < Person
-	def constructor name, age
+	constructor name, age
 		super(name, age)
 	def greet
 		console.log "Your Royal Highness, King {name}."
@@ -664,7 +664,7 @@ In the example below. `super` passes a value to the parameter `words` of the wri
 
 ```imba
 class Person
-	def constructor name
+	constructor name
 		name = name
 	def writes words
 		console.log "{name} writes an average of {words} words a day."

--- a/content/manual.md
+++ b/content/manual.md
@@ -1383,6 +1383,24 @@ dog.speak! # Mitzie barks.
 ```
 An inherited class will inherit all methods and functionality from the parent class.
 
+If the heritor class accesses any variables or functions on self in its constructor, the constructor must first call `super`.
+
+```imba
+class Animal 
+	constructor name
+		name = name
+
+class Dog < Animal
+    constructor name, breed
+        super # calls Animal constructor with the same arguments (name, breed). 
+        # super(name) # This would be an explit way to achieve the same effect
+        breed = breed
+
+let dog = new Dog 'Mitzie', 'Pug'
+console.log dog.name 
+dog.speak! # Mitzie barks.
+```
+
 ## Super
 
 ##### super

--- a/content/manual.md
+++ b/content/manual.md
@@ -962,7 +962,7 @@ Ranges **must include spaces** around `..` and `...`
 ##### toIterable [snippet]
 ```imba
 class LabelString
-    def constructor label
+    constructor label
         label = label
 
     def toIterable
@@ -1364,7 +1364,7 @@ An important feature of Classes is the ability to inherit from other classes. Fo
 
 ```imba
 class Animal 
-	def constructor name
+	constructor name
 		name = name
 
     def move distance = 0
@@ -1404,7 +1404,7 @@ class Designer < Person
 ##### super.property
 ```imba
 class Animal 
-	def constructor name
+	constructor name
 		name = name
 
     def move distance = 0
@@ -1445,7 +1445,7 @@ console.log(todo.desc) # No description
 
 ```imba
 class Point
-    def constructor x,y
+    constructor x,y
         self.x = x
         self.y = y
     
@@ -1484,7 +1484,7 @@ class Retangle
 Or
 ```imba
 class Retangle
-    def constructor height, width
+    constructor height, width
         self.height = height
         self.width = width
 ```

--- a/src/repl/workers/imba/adapter.imba
+++ b/src/repl/workers/imba/adapter.imba
@@ -5,7 +5,7 @@ export class Adapter
 	prop worker
 	prop selector
 
-	def constructor defaults, selector, worker
+	constructor defaults, selector, worker
 		defaults = defaults
 		selector = selector
 		worker = worker
@@ -29,7 +29,7 @@ export class Adapter
 
 export class DiagnosticsAdapter < Adapter
 	
-	def constructor defaults, selector, worker
+	constructor defaults, selector, worker
 		super
 
 		var onModelAdd = do |model|

--- a/src/repl/workers/imba/client.imba
+++ b/src/repl/workers/imba/client.imba
@@ -5,7 +5,7 @@ var STOP_WHEN_IDLE_FOR = 2 * 60 * 1000 # 2min
 
 export class WorkerManager
 
-	def constructor path, defaults
+	constructor path, defaults
 		path = path
 		defaults = defaults
 		worker = null

--- a/src/repl/workers/imba/worker.imba
+++ b/src/repl/workers/imba/worker.imba
@@ -7,7 +7,7 @@ export class ImbaWorker
 
 	prop ctx
 
-	def constructor ctx, options
+	constructor ctx, options
 		ctx = ctx
 		options = options
 		models = {}

--- a/src/store.imba
+++ b/src/store.imba
@@ -29,7 +29,7 @@ class Entry
 			parent.children.push(item)
 		return item
 
-	def constructor data, parent
+	constructor data, parent
 		id = counter++
 		dirty = no
 		parent = parent
@@ -118,7 +118,7 @@ class Entry
 		return true
 
 export class File < Entry
-	def constructor data, parent
+	constructor data, parent
 		super
 		body = originalBody = savedBody = data.body
 		ext = data.ext or name.split('.').pop!
@@ -194,7 +194,7 @@ export class Category < Entry
 export class Dir < Entry
 	prop examples
 
-	def constructor data, parent
+	constructor data, parent
 		super
 
 	get sections
@@ -232,7 +232,7 @@ export class Dir < Entry
 
 export class Root < Dir
 	service = null
-	def constructor
+	constructor
 		super
 
 	def connectToWorker sw

--- a/src/sw.imba
+++ b/src/sw.imba
@@ -49,7 +49,7 @@ def compileImba file
 	return file.js
 
 class File
-	def constructor service, data
+	constructor service, data
 		service = service
 		name = data.name
 		path = data.path
@@ -63,7 +63,7 @@ class Service
 	static def forClient client
 		services[client.id] ||= new self(client)
 
-	def constructor client, options = {}
+	constructor client, options = {}
 		owner = client
 		options = options
 		promises = {}
@@ -117,7 +117,7 @@ class Service
 
 class Worker
 
-	def constructor
+	constructor
 		for ev in ['message','fetch','install','activate']
 			global.addEventListener(ev,self["on{ev}"].bind(self))
 		self

--- a/src/util/shortcuts.imba
+++ b/src/util/shortcuts.imba
@@ -60,7 +60,7 @@ class HotKeyManager
 	static get instance
 		$instance ||= new self()
 
-	def constructor
+	constructor
 		combos = {'*': {}}
 		identifiers = {}
 		labels = {}


### PR DESCRIPTION
A class constructor can in imba2 be a keyword or a function. After discussing with @somebee it was decided that the main way should be as a keyword as it is not a normal function and this is aligned with the javascript implementation.

## Description

There are 3 changes
- Update docs to use `constructor` as keyword and not `def constructor`
- Update imba files in project to use `constructor` to be consistent with best practice
- Add info on calling `super` / super(...) before accessing anything inherited

## How Has This Been Tested?

Not tested as I was not able to run the project locally with https

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Documentation

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
