### PR TITLE
Add group indicators to documentation sidebar

### DIFF
--- a/content/intro.md
+++ b/content/intro.md
@@ -9,14 +9,16 @@ multipage: true
 
 Imba is a programming language for building web applications with amazing performance. It replaces and works with Javascript. You can use it both for the server and client.
 
-In Imba DOM elements *and* CSS are treated as first-class citizens. DOM elements are compiled to a [memoized DOM](/guides/advanced/performance), which is an [order of magnitude faster](https://somebee.github.io/dom-reconciler-bench/index.html) than today's virtual DOM implementations. 
+In Imba DOM elements _and_ CSS are treated as first-class citizens. DOM elements are compiled to a [memoized DOM](/guides/advanced/performance), which is an [order of magnitude faster](https://somebee.github.io/dom-reconciler-bench/index.html) than today's virtual DOM implementations.
 
 This opens up a new way of developing web applications.
 
 ### Basic Syntax
+
 Imba's minimal syntax makes it quick and flexible. Learn all the details in the [Language](/language/introduction) section.
 
 ##### Literals
+
 ```imba
 let number = 42
 let bool = yes
@@ -39,6 +41,7 @@ let details =
 ```
 
 ##### Methods
+
 ```imba
 def method param
     console.log param
@@ -51,16 +54,18 @@ def method name, {title, desc = 'no description'}
 ```
 
 ##### Functions & Callbacks
+
 ```imba
 [1,2,3,4].map do(item) item * 2
 ```
 
 ##### Class Declarations
+
 ```imba
 class Todo
     prop title
     prop completed = no
-    
+
     def complete
         completed = yes
 
@@ -69,6 +74,7 @@ let todo = new Todo 'Read introduction'
 ```
 
 ##### Loops & Iteration
+
 ```imba
 # looping over arrays
 for num,i in [1,2,3]
@@ -82,7 +88,9 @@ for num in array when num != 2
 ```
 
 ##### Elements
+
 > Elements are a native part of Imba just like strings, numbers, and other types.
+
 ```imba
 # elements are first class citizens
 const list = <ul title="reminders">
@@ -98,7 +106,8 @@ const list = <ul title="reminders">
 ```
 
 ##### Components
-> Tags are compiled down to *extremely optimized* native web components.
+
+> Tags are compiled down to _extremely optimized_ native web components.
 
 ```imba
 import {todos} from './data.imba'
@@ -119,6 +128,7 @@ imba.mount <todo-app data=todos>
 ```
 
 ##### Inline styles
+
 ```imba
 import {todos} from './data.imba'
 
@@ -133,19 +143,21 @@ import {todos} from './data.imba'
 ```
 
 ##### Scoped Styles
+
 ```imba
 import {todos} from './data.imba'
 
 tag todo-app
     css .item color:gray8 bg@hover:gray1
     css .item.done color:green8 text-decoration: line-through
-    
+
     def render
         <self> for todo in data
             <div.item .done=data.completed> <span> data.title
 ```
 
 ##### Global Styles
+
 ```imba
 global css .button
     padding: 1rem 2rem
@@ -176,6 +188,7 @@ class Reminder
 ##### Type annotations
 
 > Type annotations in Imba are compiled to jsdoc comments and are used for intelligent auto-completions and analysis in Visual Studio Code.
+
 ```imba
 let item\string = window.title
 
@@ -183,12 +196,11 @@ def multiply a\number, b\number
     a * b
 ```
 
-# Installation [wip]
+# Installation
 
 The easiest way to get started using Imba is to clone the [webpack-app-imba](https://github.com/imba/webpack-app-imba) template on GitHub and use it to start your project.
 
 Installation guide and decent starter templates coming soon. Until then, you can run `npm install imba@pre` and start exploring.
-
 
 # Community
 
@@ -196,7 +208,6 @@ Installation guide and decent starter templates coming soon. Until then, you can
 
 For questions and support please use our community chat on
 [Discord](https://discord.gg/mkcbkRw) or our [discourse](https://users.imba.io/).
-
 
 ## Bi-Weekly Meeting
 
@@ -207,4 +218,3 @@ For the exact meeting times please use the Meetup group [Imba Oslo Meetup](https
 You can join us remotely via [Zoom](https://us04web.zoom.us/j/230170873).
 
 Did you miss a meeting? No worries, catch up via the [meeting notes](https://docs.google.com/document/d/1ABGjOJut9eXrajYjdN4G4-UGGU4gvKznLk5CAaXYjso/edit?usp=sharing) or [video recordings](https://www.youtube.com/playlist?list=PLf1a9PYKGPdl3OMBHV72Oz23eFy9q51jJ).
-

--- a/content/language.md
+++ b/content/language.md
@@ -262,7 +262,7 @@ Like css and html, dashes inside identifiers are perfectly valid in Imba. Variab
 
 Identifiers starting with an uppercase letter is treated somewhat differently than other identiers...
 
-### Predicate Identifiers
+### Predicate Identifiers [wip]
 
 ### Symbol Identifiers
 
@@ -274,7 +274,7 @@ obj.name
 obj.#clearance
 ```
 
-Lone symbol identi
+<!-- Lone symbol identi -->
 
 ### Using reserved keywords
 
@@ -397,9 +397,9 @@ class Line
 
 Self always refers to the closest _selfish_ scope, and lone identifiers not declared in the lexical scope are treated as properties on self. **Uppercased identifiers are not treated as accessors**. So `Array`, `Map`, or `SomeIdentifier` will always resolve the same way they do in JavaScript.
 
-### Global variables
+### Global variables [wip]
 
-Mention the globals.
+<!-- Mention the globals. -->
 
 ### Variable hoisting
 

--- a/src/components/app-document.imba
+++ b/src/components/app-document.imba
@@ -258,9 +258,9 @@ tag doc-section
 
 
 			if data.options.wip
-				# <.wip[bg:yellow3 rd:md px:4 py:2 c:yellow9 fs:sm mb:4 bdb:yellow4]>
-				<.wip [mb:6 c:gray8/80 bg:yellow3 d:inline]>
-					"Can you help document this topic? Reach out {<a href="https://discord.gg/mkcbkRw"> "on discord"}"
+				<.wip>
+					<span.marktext>
+						"Can you help document this topic? Reach out {<a href="https://discord.gg/mkcbkRw"> "on discord"}"
 
 			if data.options.sheet
 				<doc-section-filters data=data bind:selection=filters>

--- a/src/components/app-menu.imba
+++ b/src/components/app-menu.imba
@@ -35,30 +35,22 @@ tag app-menu-item
 		$children.style.height = oldHeightStyle
 
 	css
-		.item
-			c:gray6 fw:normal pos:relative d:block
-			&.active
-				fw:500 c:gray9
-
-		.item-title
+		.item c:gray6 fw:normal pos:relative d:block
+		.item	.item-title
 			py:2px of:hidden text-overflow:ellipsis ws:nowrap
 			@hover c:gray9
-		
-		.triangle
-			c:gray5 pos:absolute t:calc(50% - 3px) l:-10px tween:transform 150ms ease-in-out
-
-		.active .triangle
-			rotate:90deg
-		
-
-
-		.children
-			pl:15px of:hidden tween:height 200ms ease-out
+		item.active fw:500 c:gray9
+		.triangle c:gray5 pos:absolute t:calc(50% - 3px) l:-10px tween:transform 150ms ease-in-out
+		.active .triangle rotate:90deg
+		.children pl:15px of:hidden tween:height 200ms ease-out
+		&.wip .item-title @after
+			pos:relative d:inline ai:center bg:yellow3 content:'wip' rd:sm
+			c:yellow7 fs:xxs/12px tt:uppercase px:1 py:0.5 rd:1 ml:1 va:middle fw:bold
 
 	def render
-		<self>
+		<self .{data.flagstr}>
 
-			<a$item.item route-to=data.href @click=(console.log(data))>
+			<a$item.item route-to=data.href>
 				<div.triangle innerHTML=triangleSVG> if hasChildren?
 				<div.item-title> data.title
 

--- a/src/components/app-menu.imba
+++ b/src/components/app-menu.imba
@@ -41,7 +41,7 @@ tag app-menu-item
 				fw:500 c:gray9
 
 		.item-title
-			py:2px 
+			py:2px of:hidden text-overflow:ellipsis ws:nowrap
 			@hover c:gray9
 		
 		.triangle

--- a/src/components/app-menu.imba
+++ b/src/components/app-menu.imba
@@ -1,44 +1,74 @@
 import {fs,files,ls} from '../store'
 
+const triangleSVG =	`
+	<svg width="5" height="6" viewBox="0 0 5 6" xmlns="http://www.w3.org/2000/svg">
+		<path d="M5 3L0.5 5.59808L0.5 0.401924L5 3Z" fill="currentColor" />
+	</svg>
+`
+
+
 tag app-menu-item
-	css transition:all 150ms cubic-in-out
-		$height:26px .l1:30px
 
-	css .item
-		p:1 2 d:block rd:1
-		c:gray6 @hover:gray9 .active:teal6
-		transition:all 150ms cubic-in-out tt.folder:capitalize
-		of:hidden text-overflow:ellipsis ws:nowrap
-		fs:sm/1.2 fw:400
-		# &.l1 fw:500 py:1.5
-		&.doc.l2 fw:400
-		&.active fw:500 c:gray9
-		&.section pl:4
-		# &.l3 fs:4/1.2 fw:400
+	levelCutoff = 40
 
-		&.wip @after
-			pos:relative d:inline ai:center bg:yellow3 content:'wip' rd:sm
-			c:yellow7 fs:xxs/12px tt:uppercase px:1 py:0.5 rd:1 ml:1 va:middle fw:bold
+	get hasChildren?
+		# only children below level cutoff are shown as child sections in the menu
+		const result = data.children.filter(do |c| c.level < levelCutoff)
+		result.length > 0
+	
+	get renderChildren?
+		hasChildren? && !data.reference?
+	
+	get active?
+		# this is a hacky way to find out if this is the active section
+		# but I don't know how the imba router works 
+		$item.className.split(/\b/).includes('active')
+	
+	# children's natural height is calculated
+	# and stored upon mount so that it can be animated to
+	# could height change after mount?
+	childrenHeight = 0
+	def mount
+		const oldHeightStyle = $children.style.height
+		$children.style.height = 'auto'
+		childrenHeight = $children.offsetHeight
+		$children.style.height = oldHeightStyle
+
+	css
+		.item
+			c:gray6 fw:normal pos:relative d:block
+			&.active
+				fw:500 c:gray9
+
+		.item-title
+			py:2px 
+			@hover c:gray9
 		
-	css .children pl:3
-	css .children > * mt:calc($height * -1) o:0 pointer-events:none
-	css .active + .children > * o:1 my:0 pointer-events:auto
+		.triangle
+			c:gray5 pos:absolute t:calc(50% - 3px) l:-10px tween:transform 150ms ease-in-out
 
-	prop level = 0
+		.active .triangle
+			rotate:90deg
+		
 
-	def jumpTo section, ev
-		console.log 'jump to',ev,section
-		self
 
-	<self[d:block].l{level} .{data.flagstr}>
-		<a.item .l{level} .{data.type} data=data .{data.flagstr} route-to=data.href> data.title
-		if data.children.length and !data.reference? # and !data.options.tabbed and data.type != 'section'
-			<div.children[d@empty:none]>
-				# for sub in data.sections when !sub.hidden
-				#	<a.segment.item.l{level + 1} data=sub .wip=sub.meta.wip href="{data.href}#{sub.slug}" @click.stop=jumpTo(sub,e)> sub.title
-				for sub in data.children
-					continue if sub.level >= 40
-					<app-menu-item.sub data=sub level=(level + 1)>
+		.children
+			pl:15px of:hidden tween:height 200ms ease-out
+
+	def render
+		<self>
+
+			<a$item.item route-to=data.href @click=(console.log(data))>
+				<div.triangle innerHTML=triangleSVG> if hasChildren?
+				<div.item-title> data.title
+
+			if renderChildren?
+				<div$children.children [h:{active? ? childrenHeight : 0}px]>
+					for child in data.children
+						continue if child.level >= levelCutoff
+						<app-menu-item.child data=child>
+
+
 	
 tag app-menu-section
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Added group indicators to the menu items that have children to be displayed, it animates to a down position when opened.
- Simplified some of the code for app-menu-item, I think it's more clear now
- Improved the appearance of the show/hide animation for the menu sections
- Unified some of the 'wip' text styles

I hope I didn't break anything.

I noticed the menu button for narrow browser widths behaves a bit weird, but seems to be an existing problem. At certain widths it activates only momentarily on press.

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

I did basic testing in chrome and safari on my mac.

<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, tests ran to see how -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [] I have read the **CONTRIBUTING** document.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
