### PR TITLE
Add info about optional chaining

### DIFF
--- a/content/language.md
+++ b/content/language.md
@@ -1217,6 +1217,16 @@ if (data.state & STATES.LOADED) == 0
 a ^=? 1 # Bitwise XOR assignment
 ```
 
+## Optional chaining [toc-pills]
+
+Imba uses `..` for [optional chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining). If the optional reference is nullish it will return undefined.
+
+```imba
+let object = {one: {value: 1})}
+console.log object..two..value # => undefined
+console.log object.two.value # => TypeError: Cannot read property 'value' of undefined
+```
+
 ## Keywords [toc-pills]
 
 ### delete [op=keyword+delete+unary]


### PR DESCRIPTION
Added basic info about the optional chaining operator linking to MDN for more info. It will now be searchable. But the placement in the operator hierarchy wasn't obvious. It can be under Logical operators like nullish coalescing or as it's own section like in MDN.

🤔: As logical operator
⭐️: As its own operator type
💬: <insert your comment>