### PR TITLE
Improve color contrast for better accessibility

### DIFF
--- a/src/components/app-document.imba
+++ b/src/components/app-document.imba
@@ -141,7 +141,7 @@ tag doc-section
 			.title bg:#364765 fs:13px ff:mono fw:700 prefix: "a " suffix: " b" c:$code-keyword
 				@before,@after fw:400 c:$code-variable
 			
-			.title bg:blue5 fs:13px ff:mono fw:700 prefix: "a " suffix: " b" c:blue9
+			.title bg:blue5 fs:13px ff:mono fw:700 prefix: "a " suffix: " b" c:black
 				@before,@after fw:400 c:white
 
 			&.op-unary .title prefix:"" suffix:"a"


### PR DESCRIPTION
This is a simple style change that only affects the operators page.

Here is why the change is needed: it improves visibility of the operator by increasing contrast.

![before_imba](https://user-images.githubusercontent.com/8558836/130317230-2305cf3c-5a78-42dc-96a4-f0d18571133d.png)
![after_imba](https://user-images.githubusercontent.com/8558836/130317232-0b2f48fa-5a8e-4c24-a216-61ed9afd0e88.png)

Here is how it looks now vs after the change

![image](https://user-images.githubusercontent.com/8558836/130317281-4f3829fe-fb4f-4868-b5be-ce244d6da787.png)


![image](https://user-images.githubusercontent.com/8558836/130317264-c566e67e-f990-4029-8b96-d0191ccf02d5.png)

