### PR TITLE
Fix fragments documentation

### DIFF
--- a/content/tags.md
+++ b/content/tags.md
@@ -283,7 +283,7 @@ tag app-dialog
 			<.body> body!
 
 
-	def  body
+	def body
 		<> # Returns all elements without any wrapping element
 			<h3> "Body text"
 			<p> "With some adjecent content"


### PR DESCRIPTION
## Description
[Basic syntax -> Fragments](https://imba.io/tags/basic-syntax#fragments) currently renders the fragment tag invalid. I think this is also the bug mentioned in #199. The issue was a double space between the `def` and the method name.

## How Has This Been Tested?
This has been tested manually in the browser. See images below for comparison.

## Types of changes

* [x] Bug fix \(non-breaking change which fixes an issue\)
* [ ] New feature \(non-breaking change which adds functionality\)
* [ ] Breaking change \(fix or feature that would cause existing functionality to not work as expected\)
* [ ] This change requires a documentation update

## Checklist:

* [x] I have read the **CONTRIBUTING** document.
* [ ] I have updated/added documentation affected by my changes.
* [ ] I have added tests to cover my changes.

## Images
Before
![CleanShot 2021-08-24 at 22 25 47@2x](https://user-images.githubusercontent.com/6446452/130685002-a8afa642-81e0-454a-ba25-fad93c149165.png)
After
<img width="734" alt="CleanShot 2021-08-24 at 22 29 49@2x" src="https://user-images.githubusercontent.com/6446452/130685520-21214f94-cb6f-4111-bf1d-26d3541391db.png">
