### PR TITLE
Replace commas by line breaks in let statement

### DIFF
--- a/content/tags.md
+++ b/content/tags.md
@@ -217,7 +217,9 @@ css mark pos:absolute
 css li d:inline-block px:1 m:1 rd:2 fs:xs bg:gray1 @hover:blue2
 
 # ---
-let x = 20, y = 20, title = "Hey"
+let x = 20
+let y = 20
+let title = "Hey"
 
 imba.mount do
     <main @mousemove=(x=e.x,y=e.y)>


### PR DESCRIPTION
Fixes bug where the example does not render.

Seems like comma-separated let statements are not supported?

I tested in in a local project and it works now.