### PR TITLE
Fix needing two clicks to open search in Safari

### DIFF
--- a/src/components/app-search.imba
+++ b/src/components/app-search.imba
@@ -55,9 +55,11 @@ tag app-search
 
 	def show
 		flags.remove('hidden')
-		clearTimeout(#hider)
-		focus!
-		$input.setSelectionRange(0,query.length)
+		# setTimeout(&, 1) do # this also works...
+		imba.commit().then do
+			clearTimeout(#hider)
+			focus!
+			$input.setSelectionRange(0,query.length)
 
 	def hide
 		# flags.remove('entered')


### PR DESCRIPTION


## Description
In safari, it requires two clicks on the "Search" button in the nav bar in order to open it. I fixed this by adding:
`imba.commit().then do` around some of the code in the `show` method that shows the search UI. I'm not sure this is the best technique, using a 1ms setTimeout also works.

## How Has This Been Tested?
In my browser locally

## Types of changes

* [x] Bug fix \(non-breaking change which fixes an issue\)
* [ ] New feature \(non-breaking change which adds functionality\)
* [ ] Breaking change \(fix or feature that would cause existing functionality to not work as expected\)
* [ ] This change requires a documentation update

## Checklist:

* [x] I have read the **CONTRIBUTING** document.
* [x] I have updated/added documentation affected by my changes.
* [x] I have added tests to cover my changes.

