### PR TITLE
Tagged template docs

### DIFF
--- a/content/docs/basic-syntax.md
+++ b/content/docs/basic-syntax.md
@@ -62,7 +62,27 @@ let string = '''
     '''
 ```
 
-> [tip amber] Tagged templates from JavaScript are on the roadmap, but not currently supported.
+Tagged templates let you parse template literals with a function:
+
+```imba
+const person = 'Mike'
+const age = 28
+
+def myTag(strings, personExp, ageExp)
+    const str0 = strings[0] # "That "
+    const str1 = strings[1] # " is a "
+    const str2 = strings[2] # "."
+
+    const ageStr = (ageExp > 99) ? 'centenarian' : 'youngster'
+
+    # We can even return a string built using a template literal
+    "{str0}{personExp}{str1}{ageStr}{str2}"
+
+const output = myTag`That {person} is a {age}.`
+
+console.log(output)
+# That Mike is a youngster.
+```
 
 ## Arrays
 


### PR DESCRIPTION
_My internet is broken and the PR description keeps getting lost._

This adds docs for [the new tagged templates](https://github.com/imba/imba/blob/206062d2f67b637b9d9e2530e575ab3752d12e96/packages/imba/test/apps/syntax/objects.imba) in Imba.

- [ ] Double check the converted Imba code from the [MDN example](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals)
- [ ] Consider making the code more idiomatic for Imba, rather than a raw conversion from JS? 