### PR TITLE
Update Marked and Passport versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "imba": "^2.0.0-alpha.223",
         "marked": "^4.1.0",
         "node-fetch": "^3.2.10",
-        "passport": "^0.4.1",
+        "passport": "^0.6.0",
         "perfect-arrows": "^0.3.3",
         "quick-score": "^0.0.13",
         "svgpath": "^2.3.0"
@@ -1077,15 +1077,20 @@
       }
     },
     "node_modules/passport": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/passport/-/passport-0.4.1.tgz",
-      "integrity": "sha512-IxXgZZs8d7uFSt3eqNjM9NQ3g3uQCW5avD8mRNoXV99Yig50vjuaez6dQK2qC0kVWPRTujxY0dWgGfT09adjYg==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/passport/-/passport-0.6.0.tgz",
+      "integrity": "sha512-0fe+p3ZnrWRW74fe8+SvCyf4a3Pb2/h7gFkQ8yTJpAO50gDzlfjZUZTO1k5Eg9kUct22OxHLqDZoKUWRHOh9ug==",
       "dependencies": {
         "passport-strategy": "1.x.x",
-        "pause": "0.0.1"
+        "pause": "0.0.1",
+        "utils-merge": "^1.0.1"
       },
       "engines": {
         "node": ">= 0.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jaredhanson"
       }
     },
     "node_modules/passport-strategy": {
@@ -2011,12 +2016,13 @@
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
     },
     "passport": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/passport/-/passport-0.4.1.tgz",
-      "integrity": "sha512-IxXgZZs8d7uFSt3eqNjM9NQ3g3uQCW5avD8mRNoXV99Yig50vjuaez6dQK2qC0kVWPRTujxY0dWgGfT09adjYg==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/passport/-/passport-0.6.0.tgz",
+      "integrity": "sha512-0fe+p3ZnrWRW74fe8+SvCyf4a3Pb2/h7gFkQ8yTJpAO50gDzlfjZUZTO1k5Eg9kUct22OxHLqDZoKUWRHOh9ug==",
       "requires": {
         "passport-strategy": "1.x.x",
-        "pause": "0.0.1"
+        "pause": "0.0.1",
+        "utils-merge": "^1.0.1"
       }
     },
     "passport-strategy": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "esbuild": "^0.15.10",
         "express": "^4.17.1",
         "imba": "^2.0.0-alpha.223",
-        "marked": "^0.7.0",
+        "marked": "^4.1.0",
         "node-fetch": "^3.2.10",
         "passport": "^0.4.1",
         "perfect-arrows": "^0.3.3",
@@ -926,14 +926,14 @@
       }
     },
     "node_modules/marked": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz",
-      "integrity": "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.1.0.tgz",
+      "integrity": "sha512-+Z6KDjSPa6/723PQYyc1axYZpYYpDnECDaU6hkaf5gqBieBkMKYReL5hteF2QizhlMbgbo8umXl/clZ67+GlsA==",
       "bin": {
-        "marked": "bin/marked"
+        "marked": "bin/marked.js"
       },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">= 12"
       }
     },
     "node_modules/media-typer": {
@@ -1919,9 +1919,9 @@
       }
     },
     "marked": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz",
-      "integrity": "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg=="
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.1.0.tgz",
+      "integrity": "sha512-+Z6KDjSPa6/723PQYyc1axYZpYYpDnECDaU6hkaf5gqBieBkMKYReL5hteF2QizhlMbgbo8umXl/clZ67+GlsA=="
     },
     "media-typer": {
       "version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "imba": "^2.0.0-alpha.223",
     "marked": "^4.1.0",
     "node-fetch": "^3.2.10",
-    "passport": "^0.4.1",
+    "passport": "^0.6.0",
     "perfect-arrows": "^0.3.3",
     "quick-score": "^0.0.13",
     "svgpath": "^2.3.0"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "esbuild": "^0.15.10",
     "express": "^4.17.1",
     "imba": "^2.0.0-alpha.223",
-    "marked": "^0.7.0",
+    "marked": "^4.1.0",
     "node-fetch": "^3.2.10",
     "passport": "^0.4.1",
     "perfect-arrows": "^0.3.3",

--- a/scripts/build-api-docs.imba
+++ b/scripts/build-api-docs.imba
@@ -5,7 +5,7 @@ import * as ts from 'typescript/lib/tsserverlibrary'
 import imba-plugin from 'typescript-imba-plugin'
 import {SymbolFlags,ModifierFlags,CategoryFlags} from '../src/util/flags'
 
-import marked from 'marked'
+import { marked } from 'marked'
 import mdn-api from './mdn-data/api/inheritance.json'
 
 const mdrenderer = new marked.Renderer
@@ -65,7 +65,7 @@ def mdrenderer.heading text, level
 	
 def toMarkdown str, meta
 	mdstate = meta or {}
-	marked(str,{
+	marked.parse(str,{
 		renderer: mdrenderer
 		sanitize: false
 	})

--- a/src/util/markdown.imba
+++ b/src/util/markdown.imba
@@ -305,7 +305,7 @@ def renderer.table header, body
 	return out.toString().replace('$HEADER$',header).replace('$BODY$',body)
 
 export def htmlify content, o = {}
-	marked(content)
+	marked.parse(content)
 
 export def render content, o = {}
 	let object = {toString: (do this.body), toc: [],meta: {}}


### PR DESCRIPTION
Addresses security vulnerabilities with super outdated `marked` and also `passport`.

## How Has This Been Tested?
Navigated to many different pages, markdown seems to be working fine.