### PR TITLE
Show hoverable anchor icons

### DIFF
--- a/src/components/app-document.imba
+++ b/src/components/app-document.imba
@@ -276,7 +276,19 @@ tag doc-section
 				<div.head[scroll-margin-top:80px] .{data.flagstr} .l{level} .h{data.data.hlevel} id=data.hash>
 					css svg d:inline size:5
 					css .legend ml:1 c:gray5 fs:md
-					<a[pos:absolute l:-20px c:gray5 o:0] href=data.href> '#'
+					css x:-10px
+						.anchor-container w:1em pos:absolute l:0px x:-100% 
+						a.anchor o:0 transition:opacity 75ms ease c:gray4 fw:300
+						&@hover a.anchor o:1
+
+					if level > 0
+						# only show the little anchor link symbols next to headers > level 0
+						# because level 0 is the top page header, which is the page you are already on
+						# the container is there to provide a little non-clickable space on the right of the # symbol
+						# which bridges the gap between the symbol and the header, so you can mouse between them
+						# without un-hovering momentarily
+						<div.anchor-container> <a.anchor href=data.href> '#'
+
 					<span.html.title innerHTML=data.head>
 					if data.legend
 						<span.legend> data.legend


### PR DESCRIPTION
Seems like these icons are supposed to appear next to headers. I set them up to appear on hover, and I accounted for the space between the icon an the header, so there isn't a non-hoverable space between them (although there is a non-clickable space, which allows for easier selecting of the title text)

<img width="206" alt="image" src="https://user-images.githubusercontent.com/6732/197619933-cb6be671-f441-406b-89d9-fe7c7f9eace5.png">

<img width="177" alt="image" src="https://user-images.githubusercontent.com/6732/197620173-2fc842c2-c6d8-4739-94ac-4b801a8fbdb7.png">
