### PR TITLE
Change `for` to `slot` in `slots.md`

### DIFF
--- a/content/docs/slots.md
+++ b/content/docs/slots.md
@@ -43,7 +43,7 @@ imba.mount <app-example>
 
 ### Named Slots [preview=md]
 
-You can also add named slots using `<slot name=...>` and render into them using `<el for=slotname>` in the outer rendering.
+You can also add named slots using `<slot name=...>` and render into them using `<el slot=slotname>` in the outer rendering.
 
 ```imba
 # ~preview


### PR DESCRIPTION
This change fixes a typo in the documentation.